### PR TITLE
Fix the router URLs

### DIFF
--- a/py_ocpi/core/dependencies.py
+++ b/py_ocpi/core/dependencies.py
@@ -22,7 +22,7 @@ def get_versions():
     return [
         Version(
             version=VersionNumber.v_2_2_1,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/{VersionNumber.v_2_2_1}/details')
+            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/{VersionNumber.v_2_2_1.value}/details')
         ).dict(),
     ]
 

--- a/py_ocpi/core/endpoints.py
+++ b/py_ocpi/core/endpoints.py
@@ -13,42 +13,42 @@ ENDPOINTS = {
             identifier=ModuleID.locations,
             role=InterfaceRole.sender,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.locations}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.locations.value}')
         ),
         # sessions
         Endpoint(
             identifier=ModuleID.sessions,
             role=InterfaceRole.sender,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.sessions}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.sessions.value}')
         ),
         # credentials
         Endpoint(
             identifier=ModuleID.credentials_and_registration,
             role=InterfaceRole.receiver,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.credentials_and_registration}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.credentials_and_registration.value}')
         ),
         # tariffs
         Endpoint(
             identifier=ModuleID.tariffs,
             role=InterfaceRole.sender,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.tariffs}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tariffs.value}')
         ),
         # cdrs
         Endpoint(
             identifier=ModuleID.cdrs,
             role=InterfaceRole.sender,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.cdrs}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.cdrs.value}')
         ),
         # tokens
         Endpoint(
             identifier=ModuleID.tokens,
             role=InterfaceRole.receiver,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.tokens}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tokens.value}')
         ),
 
         # ###############--EMSP--###############
@@ -58,49 +58,49 @@ ENDPOINTS = {
             identifier=ModuleID.credentials_and_registration,
             role=InterfaceRole.receiver,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.credentials_and_registration}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.credentials_and_registration.value}')
         ),
         # locations
         Endpoint(
             identifier=ModuleID.locations,
             role=InterfaceRole.receiver,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.locations}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.locations.value}')
         ),
         # sessions
         Endpoint(
             identifier=ModuleID.sessions,
             role=InterfaceRole.receiver,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.sessions}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.sessions.value}')
         ),
         # cdrs
         Endpoint(
             identifier=ModuleID.cdrs,
             role=InterfaceRole.receiver,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.cdrs}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.cdrs.value}')
         ),
         # tariffs
         Endpoint(
             identifier=ModuleID.tariffs,
             role=InterfaceRole.receiver,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.tariffs}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tariffs.value}')
         ),
         # commands
         Endpoint(
             identifier=ModuleID.commands,
             role=InterfaceRole.sender,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.commands}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.commands.value}')
         ),
         # tokens
         Endpoint(
             identifier=ModuleID.tokens,
             role=InterfaceRole.sender,
             url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.tokens}')
+                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tokens.value}')
         ),
     ]
 

--- a/py_ocpi/main.py
+++ b/py_ocpi/main.py
@@ -92,28 +92,28 @@ def get_application(
         if RoleEnum.cpo in roles:
             _app.include_router(
                 v_2_2_1_cpo_router,
-                prefix=f'/{settings.OCPI_PREFIX}/cpo/{VersionNumber.v_2_2_1}',
+                prefix=f'/{settings.OCPI_PREFIX}/cpo/{VersionNumber.v_2_2_1.value}',
                 tags=['CPO']
             )
 
             versions.append(
                 Version(
                     version=VersionNumber.v_2_2_1,
-                    url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo/{VersionNumber.v_2_2_1}')
+                    url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo/{VersionNumber.v_2_2_1.value}')
                 ).dict(),
             )
 
         if RoleEnum.emsp in roles:
             _app.include_router(
                 v_2_2_1_emsp_router,
-                prefix=f'/{settings.OCPI_PREFIX}/emsp/{VersionNumber.v_2_2_1}',
+                prefix=f'/{settings.OCPI_PREFIX}/emsp/{VersionNumber.v_2_2_1.value}',
                 tags=['EMSP']
             )
 
             versions.append(
                 Version(
                     version=VersionNumber.v_2_2_1,
-                    url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp/{VersionNumber.v_2_2_1}')
+                    url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp/{VersionNumber.v_2_2_1.value}')
                 ).dict(),
             )
 


### PR DESCRIPTION
The router URLs are using the `Enum` names instead of value, causing the endpoint URLs to look off:
<img width="1170" alt="Screenshot 2023-01-26 at 20 49 15" src="https://user-images.githubusercontent.com/25722/215145386-50263c55-892e-4cb9-a496-b6d7c50f3a8b.png">

This PR fixes this issue.