### PR TITLE
Split endpoints between the roles

### DIFF
--- a/py_ocpi/core/endpoints.py
+++ b/py_ocpi/core/endpoints.py
@@ -1,107 +1,108 @@
-from py_ocpi.core.enums import ModuleID
+from py_ocpi.core.enums import ModuleID, RoleEnum
 from py_ocpi.core.data_types import URL
 from py_ocpi.core.config import settings
 from py_ocpi.modules.versions.schemas import Endpoint
 from py_ocpi.modules.versions.enums import VersionNumber, InterfaceRole
 
 ENDPOINTS = {
-    VersionNumber.v_2_2_1: [
+    VersionNumber.v_2_2_1: {
         # ###############--CPO--###############
-
-        # locations
-        Endpoint(
-            identifier=ModuleID.locations,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.locations.value}')
-        ),
-        # sessions
-        Endpoint(
-            identifier=ModuleID.sessions,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.sessions.value}')
-        ),
-        # credentials
-        Endpoint(
-            identifier=ModuleID.credentials_and_registration,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.credentials_and_registration.value}')
-        ),
-        # tariffs
-        Endpoint(
-            identifier=ModuleID.tariffs,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tariffs.value}')
-        ),
-        # cdrs
-        Endpoint(
-            identifier=ModuleID.cdrs,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.cdrs.value}')
-        ),
-        # tokens
-        Endpoint(
-            identifier=ModuleID.tokens,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tokens.value}')
-        ),
+        RoleEnum.cpo: [
+            # locations
+            Endpoint(
+                identifier=ModuleID.locations,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.locations.value}')
+            ),
+            # sessions
+            Endpoint(
+                identifier=ModuleID.sessions,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.sessions.value}')
+            ),
+            # credentials
+            Endpoint(
+                identifier=ModuleID.credentials_and_registration,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.credentials_and_registration.value}')
+            ),
+            # tariffs
+            Endpoint(
+                identifier=ModuleID.tariffs,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tariffs.value}')
+            ),
+            # cdrs
+            Endpoint(
+                identifier=ModuleID.cdrs,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.cdrs.value}')
+            ),
+            # tokens
+            Endpoint(
+                identifier=ModuleID.tokens,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tokens.value}')
+            ),
+        ],
 
         # ###############--EMSP--###############
-
-        # credentials
-        Endpoint(
-            identifier=ModuleID.credentials_and_registration,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.credentials_and_registration.value}')
-        ),
-        # locations
-        Endpoint(
-            identifier=ModuleID.locations,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.locations.value}')
-        ),
-        # sessions
-        Endpoint(
-            identifier=ModuleID.sessions,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.sessions.value}')
-        ),
-        # cdrs
-        Endpoint(
-            identifier=ModuleID.cdrs,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.cdrs.value}')
-        ),
-        # tariffs
-        Endpoint(
-            identifier=ModuleID.tariffs,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tariffs.value}')
-        ),
-        # commands
-        Endpoint(
-            identifier=ModuleID.commands,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.commands.value}')
-        ),
-        # tokens
-        Endpoint(
-            identifier=ModuleID.tokens,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tokens.value}')
-        ),
-    ]
-
+        RoleEnum.emsp: [
+            # credentials
+            Endpoint(
+                identifier=ModuleID.credentials_and_registration,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.credentials_and_registration.value}')
+            ),
+            # locations
+            Endpoint(
+                identifier=ModuleID.locations,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.locations.value}')
+            ),
+            # sessions
+            Endpoint(
+                identifier=ModuleID.sessions,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.sessions.value}')
+            ),
+            # cdrs
+            Endpoint(
+                identifier=ModuleID.cdrs,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.cdrs.value}')
+            ),
+            # tariffs
+            Endpoint(
+                identifier=ModuleID.tariffs,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tariffs.value}')
+            ),
+            # commands
+            Endpoint(
+                identifier=ModuleID.commands,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.commands.value}')
+            ),
+            # tokens
+            Endpoint(
+                identifier=ModuleID.tokens,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tokens.value}')
+            ),
+        ]
+    }
 }

--- a/py_ocpi/main.py
+++ b/py_ocpi/main.py
@@ -99,7 +99,7 @@ def get_application(
             versions.append(
                 Version(
                     version=VersionNumber.v_2_2_1,
-                    url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo/{VersionNumber.v_2_2_1.value}')
+                    url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo/{VersionNumber.v_2_2_1.value}/')
                 ).dict(),
             )
 
@@ -113,7 +113,7 @@ def get_application(
             versions.append(
                 Version(
                     version=VersionNumber.v_2_2_1,
-                    url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp/{VersionNumber.v_2_2_1.value}')
+                    url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp/{VersionNumber.v_2_2_1.value}/')
                 ).dict(),
             )
 

--- a/py_ocpi/modules/versions/api/cpo.py
+++ b/py_ocpi/modules/versions/api/cpo.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+
+from py_ocpi.modules.versions.schemas import VersionDetail
+from py_ocpi.modules.versions.enums import VersionNumber
+from py_ocpi.core import status
+from py_ocpi.core.schemas import OCPIResponse
+from py_ocpi.core.endpoints import ENDPOINTS
+from py_ocpi.core.enums import RoleEnum
+
+router = APIRouter()
+
+
+@router.get("/", response_model=OCPIResponse)
+async def get_version_details():
+    return OCPIResponse(
+        data=[
+            VersionDetail(
+                version=VersionNumber.v_2_2_1,
+                endpoints=ENDPOINTS[VersionNumber.v_2_2_1][RoleEnum.cpo]
+            ).dict(),
+        ],
+        **status.OCPI_1000_GENERIC_SUCESS_CODE,
+    )

--- a/py_ocpi/modules/versions/api/emsp.py
+++ b/py_ocpi/modules/versions/api/emsp.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+
+from py_ocpi.modules.versions.schemas import VersionDetail
+from py_ocpi.modules.versions.enums import VersionNumber
+from py_ocpi.core import status
+from py_ocpi.core.schemas import OCPIResponse
+from py_ocpi.core.endpoints import ENDPOINTS
+from py_ocpi.core.enums import RoleEnum
+
+router = APIRouter()
+
+
+@router.get("/", response_model=OCPIResponse)
+async def get_version_details():
+    return OCPIResponse(
+        data=[
+            VersionDetail(
+                version=VersionNumber.v_2_2_1,
+                endpoints=ENDPOINTS[VersionNumber.v_2_2_1][RoleEnum.emsp]
+            ).dict(),
+        ],
+        **status.OCPI_1000_GENERIC_SUCESS_CODE,
+    )

--- a/py_ocpi/modules/versions/api/v_2_2_1.py
+++ b/py_ocpi/modules/versions/api/v_2_2_1.py
@@ -5,17 +5,22 @@ from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.core import status
 from py_ocpi.core.schemas import OCPIResponse
 from py_ocpi.core.endpoints import ENDPOINTS
+from py_ocpi.core.enums import RoleEnum
 
 router = APIRouter()
 
 
 @router.get("/2.2.1/details", response_model=OCPIResponse)
 async def get_version_details():
+    cpo_endpoints = ENDPOINTS[VersionNumber.v_2_2_1][RoleEnum.cpo]
+    emps_endpoints = ENDPOINTS[VersionNumber.v_2_2_1][RoleEnum.emsp]
+    endpoints = cpo_endpoints + emps_endpoints
+
     return OCPIResponse(
         data=[
             VersionDetail(
                 version=VersionNumber.v_2_2_1,
-                endpoints=ENDPOINTS[VersionNumber.v_2_2_1]
+                endpoints=endpoints
             ).dict(),
         ],
         **status.OCPI_1000_GENERIC_SUCESS_CODE,

--- a/py_ocpi/routers/v_2_2_1/cpo.py
+++ b/py_ocpi/routers/v_2_2_1/cpo.py
@@ -7,6 +7,7 @@ from py_ocpi.modules.commands.v_2_2_1.api import cpo_router as commands_cpo_2_2_
 from py_ocpi.modules.tariffs.v_2_2_1.api import cpo_router as tariffs_cpo_2_2_1_router
 from py_ocpi.modules.tokens.v_2_2_1.api import cpo_router as tokens_cpo_2_2_1_router
 from py_ocpi.modules.cdrs.v_2_2_1.api import cpo_router as cdrs_cpo_2_2_1_router
+from py_ocpi.modules.versions.api.cpo import router as versions_cpo_2_2_1_router
 
 
 router = APIRouter(
@@ -31,4 +32,7 @@ router.include_router(
 )
 router.include_router(
     cdrs_cpo_2_2_1_router
+)
+router.include_router(
+    versions_cpo_2_2_1_router
 )

--- a/py_ocpi/routers/v_2_2_1/emsp.py
+++ b/py_ocpi/routers/v_2_2_1/emsp.py
@@ -7,6 +7,7 @@ from py_ocpi.modules.cdrs.v_2_2_1.api import emsp_router as cdrs_emsp_2_2_1_rout
 from py_ocpi.modules.tariffs.v_2_2_1.api import emsp_router as tariffs_emsp_2_2_1_router
 from py_ocpi.modules.commands.v_2_2_1.api import emsp_router as commands_emsp_2_2_1_router
 from py_ocpi.modules.tokens.v_2_2_1.api import emsp_router as tokens_emsp_2_2_1_router
+from py_ocpi.modules.versions.api.emsp import router as versions_emsp_2_2_1_router
 
 
 router = APIRouter(
@@ -31,4 +32,7 @@ router.include_router(
 )
 router.include_router(
     tokens_emsp_2_2_1_router
+)
+router.include_router(
+    versions_emsp_2_2_1_router
 )


### PR DESCRIPTION
This PR splits the list of all endpoints by role allowing for separate details endpoints:

- `/ocpi/2.2.1/details` lists all
- `/ocpi/cpo/2.2.1/` lists only CPO ones
- `/ocpi/emsp/2.2.1/` lists only eMSP ones

As [declared in the spec](https://github.com/ocpi/ocpi/blob/2.2.1/version_information_endpoint.asciidoc#12-version-details-endpoint)