### PR TITLE
Use dict type instead of list for details endpoint

### DIFF
--- a/py_ocpi/core/schemas.py
+++ b/py_ocpi/core/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Union
 
 from pydantic import BaseModel
 
@@ -11,7 +11,7 @@ class OCPIResponse(BaseModel):
     """
     https://github.com/ocpi/ocpi/blob/2.2.1/transport_and_format.asciidoc#117-response-format
     """
-    data: list
+    data: Union[list, dict]
     status_code: int
     status_message: String(255)
     timestamp: DateTime = str(datetime.now(timezone.utc))

--- a/py_ocpi/modules/credentials/v_2_2_1/api/cpo.py
+++ b/py_ocpi/modules/credentials/v_2_2_1/api/cpo.py
@@ -66,7 +66,7 @@ async def post_credentials(request: Request, credentials: Credentials,
 
             if response_endpoints.status_code == fastapistatus.HTTP_200_OK:
                 # Store client credentials and generate new credentials for sender
-                endpoints = response_endpoints.json()['data'][0]
+                endpoints = response_endpoints.json()['data']
                 new_credentials = await crud.create(
                     ModuleID.credentials_and_registration, RoleEnum.cpo,
                     {

--- a/py_ocpi/modules/credentials/v_2_2_1/api/emsp.py
+++ b/py_ocpi/modules/credentials/v_2_2_1/api/emsp.py
@@ -66,7 +66,7 @@ async def post_credentials(request: Request, credentials: Credentials,
 
             if response_endpoints.status_code == fastapistatus.HTTP_200_OK:
                 # Store client credentials and generate new credentials for sender
-                endpoints = response_endpoints.json()['data'][0]
+                endpoints = response_endpoints.json()['data']
                 new_credentials = await crud.create(
                     ModuleID.credentials_and_registration, RoleEnum.emsp,
                     {

--- a/py_ocpi/modules/versions/api/v_2_2_1.py
+++ b/py_ocpi/modules/versions/api/v_2_2_1.py
@@ -12,11 +12,9 @@ router = APIRouter()
 @router.get("/2.2.1/details", response_model=OCPIResponse)
 async def get_version_details(endpoints=Depends(get_endpoints)):
     return OCPIResponse(
-        data=[
-            VersionDetail(
-                version=VersionNumber.v_2_2_1,
-                endpoints=endpoints[VersionNumber.v_2_2_1]
-            ).dict(),
-        ],
+        data=VersionDetail(
+            version=VersionNumber.v_2_2_1,
+            endpoints=endpoints[VersionNumber.v_2_2_1]
+        ).dict(),
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )


### PR DESCRIPTION
As per [OCPI documentation](https://github.com/ocpi/ocpi/blob/master/version_information_endpoint.asciidoc#12-version-details-endpoint) the version detail data should contain an object (not a list) that has `version` and `endpoints` properties.