### PR TITLE
Fix the initial authentication

### DIFF
--- a/py_ocpi/core/push.py
+++ b/py_ocpi/core/push.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Request, WebSocket, Depends
 from py_ocpi.core.adapter import Adapter
 from py_ocpi.core.crud import Crud
 from py_ocpi.core.schemas import Push, PushResponse, ReceiverResponse
-from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.utils import encode_string_base64, get_auth_token
 from py_ocpi.core.dependencies import get_crud, get_adapter
 from py_ocpi.core.enums import ModuleID, RoleEnum
 from py_ocpi.core.config import settings
@@ -66,7 +66,7 @@ async def push_object(version: VersionNumber, push: Push, crud: Crud, adapter: A
     receiver_responses = []
     for receiver in push.receivers:
         # get client endpoints
-        client_auth_token = f'Token {receiver.auth_token}'
+        client_auth_token = f'Token {encode_string_base64(receiver.auth_token)}'
         async with httpx.AsyncClient() as client:
             response = await client.get(receiver.endpoints_url,
                                         headers={'authorization': client_auth_token})

--- a/py_ocpi/core/utils.py
+++ b/py_ocpi/core/utils.py
@@ -1,4 +1,5 @@
 import urllib
+import base64
 
 from fastapi import Response, Request
 from pydantic import BaseModel
@@ -40,3 +41,7 @@ async def get_list(response: Response, filters: dict, module: ModuleID, role: Ro
 def partially_update_attributes(instance: BaseModel, attributes: dict):
     for key, value in attributes.items():
         setattr(instance, key, value)
+
+def encode_string_base64(input: str) -> str:
+    input_bytes = base64.b64encode(bytes(input, 'utf-8'))
+    return input_bytes.decode('utf-8')

--- a/py_ocpi/core/utils.py
+++ b/py_ocpi/core/utils.py
@@ -19,7 +19,10 @@ def set_pagination_headers(response: Response, link: str, total: int, limit: int
 def get_auth_token(request: Request) -> str:
     headers = request.headers
     headers_token = headers.get('authorization', 'Token Null')
-    return headers_token.split()[1]
+    token = headers_token.split()[1]
+    if token == 'Null':
+        return None
+    return decode_string_base64(token)
 
 
 async def get_list(response: Response, filters: dict, module: ModuleID, role: RoleEnum,
@@ -44,4 +47,8 @@ def partially_update_attributes(instance: BaseModel, attributes: dict):
 
 def encode_string_base64(input: str) -> str:
     input_bytes = base64.b64encode(bytes(input, 'utf-8'))
+    return input_bytes.decode('utf-8')
+
+def decode_string_base64(input: str) -> str:
+    input_bytes = base64.b64decode(bytes(input, 'utf-8'))
     return input_bytes.decode('utf-8')

--- a/py_ocpi/modules/commands/v_2_2_1/api/cpo.py
+++ b/py_ocpi/modules/commands/v_2_2_1/api/cpo.py
@@ -13,7 +13,7 @@ from py_ocpi.core.schemas import OCPIResponse
 from py_ocpi.core.adapter import Adapter
 from py_ocpi.core.crud import Crud
 from py_ocpi.core import status
-from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.utils import encode_string_base64, get_auth_token
 from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.modules.commands.v_2_2_1.enums import CommandType
 from py_ocpi.modules.commands.v_2_2_1.schemas import (
@@ -59,7 +59,7 @@ async def send_command_result(response_url: str, command: CommandType, auth_toke
         command_result = adapter.command_result_adapter(command_result, VersionNumber.v_2_2_1)
 
     async with httpx.AsyncClient() as client:
-        authorization_token = f'Token {client_auth_token}'
+        authorization_token = f'Token {encode_string_base64(client_auth_token)}'
         await client.post(response_url, json=command_result.dict(), headers={'authorization': authorization_token})
 
 

--- a/py_ocpi/modules/credentials/v_2_2_1/api/cpo.py
+++ b/py_ocpi/modules/credentials/v_2_2_1/api/cpo.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status as fastap
 from py_ocpi.core.schemas import OCPIResponse
 from py_ocpi.core.adapter import Adapter
 from py_ocpi.core.crud import Crud
-from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.utils import encode_string_base64, get_auth_token
 from py_ocpi.core.dependencies import get_crud, get_adapter
 from py_ocpi.core import status
 from py_ocpi.core.enums import Action, ModuleID, RoleEnum
@@ -43,7 +43,7 @@ async def post_credentials(request: Request, credentials: Credentials,
 
     # Retrieve the versions and endpoints from the client
     async with httpx.AsyncClient() as client:
-        authorization_token = f'Token {credentials_client_token}'
+        authorization_token = f'Token {encode_string_base64(credentials_client_token)}'
         response_versions = await client.get(credentials.url,
                                              headers={'authorization': authorization_token})
 
@@ -102,7 +102,7 @@ async def update_credentials(request: Request, credentials: Credentials,
 
     # Retrieve the versions and endpoints from the client
     async with httpx.AsyncClient() as client:
-        authorization_token = f'Token {credentials_client_token}'
+        authorization_token = f'Token {encode_string_base64(credentials_client_token)}'
         response_versions = await client.get(credentials.url, headers={'authorization': authorization_token})
 
         if response_versions.status_code == fastapistatus.HTTP_200_OK:

--- a/py_ocpi/modules/credentials/v_2_2_1/api/emsp.py
+++ b/py_ocpi/modules/credentials/v_2_2_1/api/emsp.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status as fastap
 from py_ocpi.core.schemas import OCPIResponse
 from py_ocpi.core.adapter import Adapter
 from py_ocpi.core.crud import Crud
-from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.utils import encode_string_base64, get_auth_token
 from py_ocpi.core.dependencies import get_crud, get_adapter
 from py_ocpi.core import status
 from py_ocpi.core.enums import Action, ModuleID, RoleEnum
@@ -43,7 +43,7 @@ async def post_credentials(request: Request, credentials: Credentials,
 
     # Retrieve the versions and endpoints from the client
     async with httpx.AsyncClient() as client:
-        authorization_token = f'Token {credentials_client_token}'
+        authorization_token = f'Token {encode_string_base64(credentials_client_token)}'
         response_versions = await client.get(credentials.url,
                                              headers={'authorization': authorization_token})
 
@@ -102,7 +102,7 @@ async def update_credentials(request: Request, credentials: Credentials,
 
     # Retrieve the versions and endpoints from the client
     async with httpx.AsyncClient() as client:
-        authorization_token = f'Token {credentials_client_token}'
+        authorization_token = f'Token {encode_string_base64(credentials_client_token)}'
         response_versions = await client.get(credentials.url, headers={'authorization': authorization_token})
 
         if response_versions.status_code == fastapistatus.HTTP_200_OK:

--- a/py_ocpi/modules/versions/api/v_2_2_1.py
+++ b/py_ocpi/modules/versions/api/v_2_2_1.py
@@ -1,16 +1,26 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request, HTTPException, status as fastapistatus
 
 from py_ocpi.modules.versions.schemas import VersionDetail
 from py_ocpi.modules.versions.enums import VersionNumber
+from py_ocpi.core.crud import Crud
 from py_ocpi.core import status
 from py_ocpi.core.schemas import OCPIResponse
-from py_ocpi.core.dependencies import get_endpoints
-
+from py_ocpi.core.dependencies import get_endpoints, get_crud
+from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.enums import Action, ModuleID, RoleEnum
 router = APIRouter()
 
 
 @router.get("/2.2.1/details", response_model=OCPIResponse)
-async def get_version_details(endpoints=Depends(get_endpoints)):
+async def get_version_details(request: Request, endpoints=Depends(get_endpoints),
+                              crud: Crud = Depends(get_crud)):
+    auth_token = get_auth_token(request)
+
+    server_cred = await crud.do(ModuleID.credentials_and_registration, None, Action.get_client_token,
+                                auth_token=auth_token)
+    if server_cred is None:
+        raise HTTPException(fastapistatus.HTTP_401_UNAUTHORIZED, "Unauthorized")
+
     return OCPIResponse(
         data=VersionDetail(
             version=VersionNumber.v_2_2_1,


### PR DESCRIPTION
This PR addresses two main issues during the initial token exchange:

1. The token in the HTTP header is base64 encoded. The ab3c3ee decodes the incoming one and e03a42e encodes it when making requests
2. As specified in the OCPI spec 4.1.2. Authorization header:
> Every OCPI HTTP request **MUST** add an 'Authorization' header

Currently, anyone who knows the URL of the versions endpoint is able to initiate the credentials exchange which is a huge security risk. 3fbb51d adds a call to CRUD to validate the incoming token and comply with **OCPI Registration process** flow described in section **7.1.1. Registration**.