### PR TITLE
Fixing credentials module endpoint retreival

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'develop'
       - 'feature/**'
+      - 'fix/**'
 
 jobs:
   lint:

--- a/py_ocpi/__init__.py
+++ b/py_ocpi/__init__.py
@@ -1,6 +1,6 @@
 """Python Implementation of OCPI"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .core import enums, data_types
 from .main import get_application

--- a/py_ocpi/core/dependencies.py
+++ b/py_ocpi/core/dependencies.py
@@ -22,9 +22,13 @@ def get_versions():
     return [
         Version(
             version=VersionNumber.v_2_2_1,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/{VersionNumber.v_2_2_1}/details')
+            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/{VersionNumber.v_2_2_1.value}/details')
         ).dict(),
     ]
+
+
+def get_endpoints():
+    return {}
 
 
 def pagination_filters(

--- a/py_ocpi/core/endpoints.py
+++ b/py_ocpi/core/endpoints.py
@@ -1,107 +1,108 @@
-from py_ocpi.core.enums import ModuleID
+from py_ocpi.core.enums import ModuleID, RoleEnum
 from py_ocpi.core.data_types import URL
 from py_ocpi.core.config import settings
 from py_ocpi.modules.versions.schemas import Endpoint
 from py_ocpi.modules.versions.enums import VersionNumber, InterfaceRole
 
 ENDPOINTS = {
-    VersionNumber.v_2_2_1: [
+    VersionNumber.v_2_2_1: {
         # ###############--CPO--###############
-
-        # locations
-        Endpoint(
-            identifier=ModuleID.locations,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.locations}')
-        ),
-        # sessions
-        Endpoint(
-            identifier=ModuleID.sessions,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.sessions}')
-        ),
-        # credentials
-        Endpoint(
-            identifier=ModuleID.credentials_and_registration,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.credentials_and_registration}')
-        ),
-        # tariffs
-        Endpoint(
-            identifier=ModuleID.tariffs,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.tariffs}')
-        ),
-        # cdrs
-        Endpoint(
-            identifier=ModuleID.cdrs,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.cdrs}')
-        ),
-        # tokens
-        Endpoint(
-            identifier=ModuleID.tokens,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.tokens}')
-        ),
+        RoleEnum.cpo: [
+            # locations
+            Endpoint(
+                identifier=ModuleID.locations,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.locations.value}')
+            ),
+            # sessions
+            Endpoint(
+                identifier=ModuleID.sessions,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.sessions.value}')
+            ),
+            # credentials
+            Endpoint(
+                identifier=ModuleID.credentials_and_registration,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.credentials_and_registration.value}')
+            ),
+            # tariffs
+            Endpoint(
+                identifier=ModuleID.tariffs,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tariffs.value}')
+            ),
+            # cdrs
+            Endpoint(
+                identifier=ModuleID.cdrs,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.cdrs.value}')
+            ),
+            # tokens
+            Endpoint(
+                identifier=ModuleID.tokens,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/cpo'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tokens.value}')
+            ),
+        ],
 
         # ###############--EMSP--###############
-
-        # credentials
-        Endpoint(
-            identifier=ModuleID.credentials_and_registration,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.credentials_and_registration}')
-        ),
-        # locations
-        Endpoint(
-            identifier=ModuleID.locations,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.locations}')
-        ),
-        # sessions
-        Endpoint(
-            identifier=ModuleID.sessions,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.sessions}')
-        ),
-        # cdrs
-        Endpoint(
-            identifier=ModuleID.cdrs,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.cdrs}')
-        ),
-        # tariffs
-        Endpoint(
-            identifier=ModuleID.tariffs,
-            role=InterfaceRole.receiver,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.tariffs}')
-        ),
-        # commands
-        Endpoint(
-            identifier=ModuleID.commands,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.commands}')
-        ),
-        # tokens
-        Endpoint(
-            identifier=ModuleID.tokens,
-            role=InterfaceRole.sender,
-            url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
-                    f'/{VersionNumber.v_2_2_1}/{ModuleID.tokens}')
-        ),
-    ]
-
+        RoleEnum.emsp: [
+            # credentials
+            Endpoint(
+                identifier=ModuleID.credentials_and_registration,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.credentials_and_registration.value}')
+            ),
+            # locations
+            Endpoint(
+                identifier=ModuleID.locations,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.locations.value}')
+            ),
+            # sessions
+            Endpoint(
+                identifier=ModuleID.sessions,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.sessions.value}')
+            ),
+            # cdrs
+            Endpoint(
+                identifier=ModuleID.cdrs,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.cdrs.value}')
+            ),
+            # tariffs
+            Endpoint(
+                identifier=ModuleID.tariffs,
+                role=InterfaceRole.receiver,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tariffs.value}')
+            ),
+            # commands
+            Endpoint(
+                identifier=ModuleID.commands,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.commands.value}')
+            ),
+            # tokens
+            Endpoint(
+                identifier=ModuleID.tokens,
+                role=InterfaceRole.sender,
+                url=URL(f'https://{settings.OCPI_HOST}/{settings.OCPI_PREFIX}/emsp'
+                        f'/{VersionNumber.v_2_2_1.value}/{ModuleID.tokens.value}')
+            ),
+        ]
+    }
 }

--- a/py_ocpi/core/push.py
+++ b/py_ocpi/core/push.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Request, WebSocket, Depends
 from py_ocpi.core.adapter import Adapter
 from py_ocpi.core.crud import Crud
 from py_ocpi.core.schemas import Push, PushResponse, ReceiverResponse
-from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.utils import encode_string_base64, get_auth_token
 from py_ocpi.core.dependencies import get_crud, get_adapter
 from py_ocpi.core.enums import ModuleID, RoleEnum
 from py_ocpi.core.config import settings
@@ -66,7 +66,7 @@ async def push_object(version: VersionNumber, push: Push, crud: Crud, adapter: A
     receiver_responses = []
     for receiver in push.receivers:
         # get client endpoints
-        client_auth_token = f'Token {receiver.auth_token}'
+        client_auth_token = f'Token {encode_string_base64(receiver.auth_token)}'
         async with httpx.AsyncClient() as client:
             response = await client.get(receiver.endpoints_url,
                                         headers={'authorization': client_auth_token})

--- a/py_ocpi/core/schemas.py
+++ b/py_ocpi/core/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Union
 
 from pydantic import BaseModel
 
@@ -11,7 +11,7 @@ class OCPIResponse(BaseModel):
     """
     https://github.com/ocpi/ocpi/blob/2.2.1/transport_and_format.asciidoc#117-response-format
     """
-    data: list
+    data: Union[list, dict]
     status_code: int
     status_message: String(255)
     timestamp: DateTime = str(datetime.now(timezone.utc))

--- a/py_ocpi/core/utils.py
+++ b/py_ocpi/core/utils.py
@@ -1,4 +1,5 @@
 import urllib
+import base64
 
 from fastapi import Response, Request
 from pydantic import BaseModel
@@ -18,7 +19,10 @@ def set_pagination_headers(response: Response, link: str, total: int, limit: int
 def get_auth_token(request: Request) -> str:
     headers = request.headers
     headers_token = headers.get('authorization', 'Token Null')
-    return headers_token.split()[1]
+    token = headers_token.split()[1]
+    if token == 'Null':  # nosec
+        return None
+    return decode_string_base64(token)
 
 
 async def get_list(response: Response, filters: dict, module: ModuleID, role: RoleEnum,
@@ -40,3 +44,13 @@ async def get_list(response: Response, filters: dict, module: ModuleID, role: Ro
 def partially_update_attributes(instance: BaseModel, attributes: dict):
     for key, value in attributes.items():
         setattr(instance, key, value)
+
+
+def encode_string_base64(input: str) -> str:
+    input_bytes = base64.b64encode(bytes(input, 'utf-8'))
+    return input_bytes.decode('utf-8')
+
+
+def decode_string_base64(input: str) -> str:
+    input_bytes = base64.b64decode(bytes(input, 'utf-8'))
+    return input_bytes.decode('utf-8')

--- a/py_ocpi/modules/cdrs/v_2_2_1/schemas.py
+++ b/py_ocpi/modules/cdrs/v_2_2_1/schemas.py
@@ -43,7 +43,7 @@ class ChargingPeriod(BaseModel):
     https://github.com/ocpi/ocpi/blob/2.2.1/mod_cdrs.asciidoc#146-chargingperiod-class
     """
     start_date_time: DateTime
-    diemnsions: List[CdrDimension]
+    dimensions: List[CdrDimension]
     tariff_id: Optional[CiString(36)]
 
 

--- a/py_ocpi/modules/commands/v_2_2_1/api/cpo.py
+++ b/py_ocpi/modules/commands/v_2_2_1/api/cpo.py
@@ -13,7 +13,7 @@ from py_ocpi.core.schemas import OCPIResponse
 from py_ocpi.core.adapter import Adapter
 from py_ocpi.core.crud import Crud
 from py_ocpi.core import status
-from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.utils import encode_string_base64, get_auth_token
 from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.modules.commands.v_2_2_1.enums import CommandType
 from py_ocpi.modules.commands.v_2_2_1.schemas import (
@@ -59,7 +59,7 @@ async def send_command_result(response_url: str, command: CommandType, auth_toke
         command_result = adapter.command_result_adapter(command_result, VersionNumber.v_2_2_1)
 
     async with httpx.AsyncClient() as client:
-        authorization_token = f'Token {client_auth_token}'
+        authorization_token = f'Token {encode_string_base64(client_auth_token)}'
         await client.post(response_url, json=command_result.dict(), headers={'authorization': authorization_token})
 
 

--- a/py_ocpi/modules/credentials/v_2_2_1/api/cpo.py
+++ b/py_ocpi/modules/credentials/v_2_2_1/api/cpo.py
@@ -66,7 +66,7 @@ async def post_credentials(request: Request, credentials: Credentials,
 
             if response_endpoints.status_code == fastapistatus.HTTP_200_OK:
                 # Store client credentials and generate new credentials for sender
-                endpoints = response_endpoints.json()['data']
+                endpoints = response_endpoints.json()['data']['endpoints']
                 new_credentials = await crud.create(
                     ModuleID.credentials_and_registration, RoleEnum.cpo,
                     {
@@ -124,7 +124,7 @@ async def update_credentials(request: Request, credentials: Credentials,
 
             if response_endpoints.status_code == fastapistatus.HTTP_200_OK:
                 # Update server credentials to access client's system and generate new credentials token
-                endpoints = response_endpoints.json()['data'][0]
+                endpoints = response_endpoints.json()['data']['endpoints']
                 new_credentials = await crud.update(ModuleID.credentials_and_registration, RoleEnum.cpo,
                                                     {
                                                         "credentials": credentials.dict(),

--- a/py_ocpi/modules/credentials/v_2_2_1/api/emsp.py
+++ b/py_ocpi/modules/credentials/v_2_2_1/api/emsp.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status as fastap
 from py_ocpi.core.schemas import OCPIResponse
 from py_ocpi.core.adapter import Adapter
 from py_ocpi.core.crud import Crud
-from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.utils import encode_string_base64, get_auth_token
 from py_ocpi.core.dependencies import get_crud, get_adapter
 from py_ocpi.core import status
 from py_ocpi.core.enums import Action, ModuleID, RoleEnum
@@ -24,7 +24,7 @@ async def get_credentials(request: Request, crud: Crud = Depends(get_crud), adap
     data = await crud.get(ModuleID.credentials_and_registration, RoleEnum.emsp,
                           auth_token, auth_token=auth_token, version=VersionNumber.v_2_2_1)
     return OCPIResponse(
-        data=[adapter.credentials_adapter(data).dict()],
+        data=adapter.credentials_adapter(data).dict(),
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )
 
@@ -43,7 +43,7 @@ async def post_credentials(request: Request, credentials: Credentials,
 
     # Retrieve the versions and endpoints from the client
     async with httpx.AsyncClient() as client:
-        authorization_token = f'Token {credentials_client_token}'
+        authorization_token = f'Token {encode_string_base64(credentials_client_token)}'
         response_versions = await client.get(credentials.url,
                                              headers={'authorization': authorization_token})
 
@@ -66,7 +66,7 @@ async def post_credentials(request: Request, credentials: Credentials,
 
             if response_endpoints.status_code == fastapistatus.HTTP_200_OK:
                 # Store client credentials and generate new credentials for sender
-                endpoints = response_endpoints.json()['data'][0]
+                endpoints = response_endpoints.json()['data']
                 new_credentials = await crud.create(
                     ModuleID.credentials_and_registration, RoleEnum.emsp,
                     {
@@ -78,7 +78,7 @@ async def post_credentials(request: Request, credentials: Credentials,
                 )
 
                 return OCPIResponse(
-                    data=[adapter.credentials_adapter(new_credentials).dict()],
+                    data=adapter.credentials_adapter(new_credentials).dict(),
                     **status.OCPI_1000_GENERIC_SUCESS_CODE
                 )
 
@@ -102,7 +102,7 @@ async def update_credentials(request: Request, credentials: Credentials,
 
     # Retrieve the versions and endpoints from the client
     async with httpx.AsyncClient() as client:
-        authorization_token = f'Token {credentials_client_token}'
+        authorization_token = f'Token {encode_string_base64(credentials_client_token)}'
         response_versions = await client.get(credentials.url, headers={'authorization': authorization_token})
 
         if response_versions.status_code == fastapistatus.HTTP_200_OK:
@@ -134,7 +134,7 @@ async def update_credentials(request: Request, credentials: Credentials,
                                                     version=VersionNumber.v_2_2_1)
 
                 return OCPIResponse(
-                    data=[adapter.credentials_adapter(new_credentials).dict()],
+                    data=adapter.credentials_adapter(new_credentials).dict(),
                     **status.OCPI_1000_GENERIC_SUCESS_CODE
                 )
 

--- a/py_ocpi/modules/versions/api/v_2_2_1.py
+++ b/py_ocpi/modules/versions/api/v_2_2_1.py
@@ -1,22 +1,30 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Request, HTTPException, status as fastapistatus
 
 from py_ocpi.modules.versions.schemas import VersionDetail
 from py_ocpi.modules.versions.enums import VersionNumber
+from py_ocpi.core.crud import Crud
 from py_ocpi.core import status
 from py_ocpi.core.schemas import OCPIResponse
-from py_ocpi.core.endpoints import ENDPOINTS
-
+from py_ocpi.core.dependencies import get_endpoints, get_crud
+from py_ocpi.core.utils import get_auth_token
+from py_ocpi.core.enums import Action, ModuleID
 router = APIRouter()
 
 
 @router.get("/2.2.1/details", response_model=OCPIResponse)
-async def get_version_details():
+async def get_version_details(request: Request, endpoints=Depends(get_endpoints),
+                              crud: Crud = Depends(get_crud)):
+    auth_token = get_auth_token(request)
+
+    server_cred = await crud.do(ModuleID.credentials_and_registration, None, Action.get_client_token,
+                                auth_token=auth_token)
+    if server_cred is None:
+        raise HTTPException(fastapistatus.HTTP_401_UNAUTHORIZED, "Unauthorized")
+
     return OCPIResponse(
-        data=[
-            VersionDetail(
-                version=VersionNumber.v_2_2_1,
-                endpoints=ENDPOINTS[VersionNumber.v_2_2_1]
-            ).dict(),
-        ],
+        data=VersionDetail(
+            version=VersionNumber.v_2_2_1,
+            endpoints=endpoints[VersionNumber.v_2_2_1]
+        ).dict(),
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py_ocpi"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python Implementation of OCPI"
 authors = ["HAkhavan71 <hakh.27@gmail.com>"]
 readme = "README.rst"

--- a/tests/test_modules/mocks/async_client.py
+++ b/tests/test_modules/mocks/async_client.py
@@ -1,5 +1,6 @@
 from py_ocpi.core.dependencies import get_versions
 from py_ocpi.core.endpoints import ENDPOINTS
+from py_ocpi.core.enums import RoleEnum
 from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.modules.versions.schemas import VersionDetail
 
@@ -7,7 +8,7 @@ fake_endpoints_data = {
     'data': [
         VersionDetail(
             version=VersionNumber.v_2_2_1,
-            endpoints=ENDPOINTS[VersionNumber.v_2_2_1]
+            endpoints=ENDPOINTS[VersionNumber.v_2_2_1][RoleEnum.cpo]
         ).dict(),
     ],
 }

--- a/tests/test_modules/test_cdrs.py
+++ b/tests/test_modules/test_cdrs.py
@@ -46,7 +46,7 @@ CDRS = [
         'charging_periods': [
             {
                 'start_date_time': '2022-01-02 00:00:00+00:00',
-                'diemnsions': [
+                'dimensions': [
                     {
                         'type': CdrDimensionType.power,
                         'volume': 10

--- a/tests/test_modules/test_commands.py
+++ b/tests/test_modules/test_commands.py
@@ -26,6 +26,9 @@ class Crud:
     @classmethod
     async def do(cls, module: enums.ModuleID, role: enums.RoleEnum, action: enums.Action,
                  *args, data: dict = None, **kwargs) -> dict:
+        if action == enums.Action.get_client_token:
+            return 'foo'
+
         return COMMAND_RESPONSE
 
     @classmethod
@@ -68,7 +71,7 @@ def test_cpo_receive_command_start_session_v_2_2_1():
     }
 
     client = TestClient(app)
-    response = client.post(f'/ocpi/cpo/2.2.1/commands/{CommandType.start_session}', json=data)
+    response = client.post(f'/ocpi/cpo/2.2.1/commands/{CommandType.start_session.value}', json=data)
 
     assert response.status_code == 200
     assert len(response.json()['data']) == 1
@@ -84,7 +87,7 @@ def test_cpo_receive_command_stop_session_v_2_2_1():
     }
 
     client = TestClient(app)
-    response = client.post(f'/ocpi/cpo/2.2.1/commands/{CommandType.stop_session}', json=data)
+    response = client.post(f'/ocpi/cpo/2.2.1/commands/{CommandType.stop_session.value}', json=data)
 
     assert response.status_code == 200
     assert len(response.json()['data']) == 1
@@ -114,7 +117,7 @@ def test_cpo_receive_command_reserve_now_v_2_2_1():
     }
 
     client = TestClient(app)
-    response = client.post(f'/ocpi/cpo/2.2.1/commands/{CommandType.reserve_now}', json=data)
+    response = client.post(f'/ocpi/cpo/2.2.1/commands/{CommandType.reserve_now.value}', json=data)
 
     assert response.status_code == 200
     assert len(response.json()['data']) == 1
@@ -154,7 +157,7 @@ def test_cpo_receive_command_reserve_now_unknown_location_v_2_2_1():
     }
 
     client = TestClient(app)
-    response = client.post(f'/ocpi/cpo/2.2.1/commands/{CommandType.reserve_now}', json=data)
+    response = client.post(f'/ocpi/cpo/2.2.1/commands/{CommandType.reserve_now.value}', json=data)
 
     assert response.status_code == 200
     assert response.json()['data'][0]['result'] == CommandResultType.rejected

--- a/tests/test_modules/test_credentials.py
+++ b/tests/test_modules/test_credentials.py
@@ -1,6 +1,7 @@
 import functools
 from uuid import uuid4
 from unittest.mock import patch
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -11,6 +12,7 @@ from py_ocpi.core import enums
 from py_ocpi.core.data_types import URL
 from py_ocpi.core.config import settings
 from py_ocpi.core.dependencies import get_versions
+from py_ocpi.core.utils import encode_string_base64
 from py_ocpi.modules.credentials.v_2_2_1.schemas import Credentials
 from py_ocpi.modules.tokens.v_2_2_1.enums import AllowedType
 from py_ocpi.modules.tokens.v_2_2_1.schemas import AuthorizationInfo, Token
@@ -80,27 +82,31 @@ def test_cpo_get_credentials_v_2_2_1():
     app = get_application(VersionNumber.v_2_2_1, [enums.RoleEnum.cpo], Crud, Adapter)
     token = str(uuid4())
     header = {
-        "Authorization": f'Token {token}'
+        "Authorization": f'Token {encode_string_base64(token)}'
     }
 
     client = TestClient(app)
     response = client.get('/ocpi/cpo/2.2.1/credentials', headers=header)
 
     assert response.status_code == 200
-    assert len(response.json()['data']) == 1
-    assert response.json()['data'][0]['token'] == token
+    assert response.json()['data']['token'] == token
 
 
 @pytest.mark.asyncio
 @patch('py_ocpi.modules.credentials.v_2_2_1.api.cpo.httpx.AsyncClient')
 async def test_cpo_post_credentials_v_2_2_1(async_client):
-    app_1 = get_application(VersionNumber.v_2_2_1, [enums.RoleEnum.emsp], Crud, Adapter)
+    class MockCrud(Crud):
+        @classmethod
+        async def do(cls, module: enums.ModuleID, role: enums.RoleEnum, action: enums.Action, auth_token, *args, data: dict = None, **kwargs) -> Any:
+            return {}
+
+    app_1 = get_application(VersionNumber.v_2_2_1, [enums.RoleEnum.emsp], MockCrud, Adapter)
 
     def override_get_versions():
         return [
             Version(
                 version=VersionNumber.v_2_2_1,
-                url=URL(f'/{settings.OCPI_PREFIX}/{VersionNumber.v_2_2_1}/details')
+                url=URL(f'/{settings.OCPI_PREFIX}/{VersionNumber.v_2_2_1.value}/details')
             ).dict()
         ]
 
@@ -108,11 +114,11 @@ async def test_cpo_post_credentials_v_2_2_1(async_client):
 
     async_client.return_value = AsyncClient(app=app_1, base_url="http://test")
 
-    app_2 = get_application(VersionNumber.v_2_2_1, [enums.RoleEnum.cpo], Crud, Adapter)
+
+    app_2 = get_application(VersionNumber.v_2_2_1, [enums.RoleEnum.cpo], MockCrud, Adapter)
 
     async with AsyncClient(app=app_2, base_url="http://test") as client:
         response = await client.post('/ocpi/cpo/2.2.1/credentials/', json=CREDENTIALS_TOKEN_CREATE)
 
     assert response.status_code == 200
-    assert len(response.json()['data']) == 1
-    assert response.json()['data'][0]['token'] == CREDENTIALS_TOKEN_CREATE['token']
+    assert response.json()['data']['token'] == CREDENTIALS_TOKEN_CREATE['token']

--- a/tests/test_modules/test_sessions.py
+++ b/tests/test_modules/test_sessions.py
@@ -34,7 +34,7 @@ SESSIONS = [
         'charging_periods': [
             {
                 'start_date_time': '2022-01-02 00:00:00+00:00',
-                'diemnsions': [
+                'dimensions': [
                     {
                         'type': CdrDimensionType.power,
                         'volume': 10

--- a/tests/test_modules/test_versions.py
+++ b/tests/test_modules/test_versions.py
@@ -1,14 +1,13 @@
-from uuid import uuid4
+from typing import Any
 
 from fastapi.testclient import TestClient
 
 from py_ocpi.main import get_application
 from py_ocpi.core import enums
-from py_ocpi.core.config import settings
 from py_ocpi.core.crud import Crud
 from py_ocpi.core.adapter import Adapter
-from py_ocpi.modules.locations.v_2_2_1.schemas import Location
 from py_ocpi.modules.versions.enums import VersionNumber
+from py_ocpi.core.enums import ModuleID, RoleEnum, Action
 
 
 def test_get_versions():
@@ -23,11 +22,31 @@ def test_get_versions():
 
 
 def test_get_versions_v_2_2_1():
+    token = None
+    class MockCrud(Crud):
+        @classmethod
+        async def do(cls, module: ModuleID, role: RoleEnum, action: Action, auth_token, *args, data: dict = None, **kwargs) -> Any:
+            nonlocal token
+            token = auth_token
+            return {}
+
+    app = get_application(VersionNumber.v_2_2_1, [enums.RoleEnum.cpo], MockCrud, Adapter)
+
+    client = TestClient(app)
+    response = client.get('/ocpi/2.2.1/details', headers={
+        'authorization': 'Token Zm9v'
+    })
+
+    assert response.status_code == 200
+    assert response.json()['data']['version'] == '2.2.1'
+    assert token == 'foo'
+
+
+def test_get_versions_v_2_2_1_requires_auth():
 
     app = get_application(VersionNumber.v_2_2_1, [enums.RoleEnum.cpo], Crud, Adapter)
 
     client = TestClient(app)
     response = client.get('/ocpi/2.2.1/details')
 
-    assert response.status_code == 200
-    assert response.json()['data'][0]['version'] == '2.2.1'
+    assert response.status_code == 401


### PR DESCRIPTION
https://github.com/TECHS-Technological-Solutions/ocpi/issues/53

In regards to this issue, I propose the following fix.

Both in the POST as the PUT the issue was present. With PUT it was breaking, with POST it would save all present in the data-object (so also the 'version' field) of the request body.

Added a test that tests the sunny day case  of this implementation.