### PR TITLE
Default value of date_to not updating in pagination_filters

### DIFF
--- a/py_ocpi/core/dependencies.py
+++ b/py_ocpi/core/dependencies.py
@@ -33,7 +33,7 @@ def get_endpoints():
 
 def pagination_filters(
     date_from: datetime = Query(default=None),
-    date_to: datetime = Query(default=datetime.now()),
+    date_to: datetime = Query(default=None),
     offset: int = Query(default=0),
     limit: int = Query(default=50),
 ):


### PR DESCRIPTION
## Updated the `pagination_filters` function to handle flexible date filtering. 
### 1. Fixed the `date_to` default value to avoid mutable default issues.
### 2. Ensures robust support for API pagination and filtering use cases.
### *Note: Users relying on old defaults should adjust their calls accordingly.*
